### PR TITLE
Cap achievement weighting at 33%

### DIFF
--- a/backend/src/routes/leaderboard.routes.ts
+++ b/backend/src/routes/leaderboard.routes.ts
@@ -25,8 +25,11 @@ router.get('/', authenticate, async (req, res) => {
         CASE 
           WHEN (COALESCE(c.calls_target, 0) + COALESCE(c.emails_target, 0) + COALESCE(c.meetings_target, 0)) > 0
           THEN ROUND(
-            ((COALESCE(r.calls_actual, 0) + COALESCE(r.emails_actual, 0) + COALESCE(r.meetings_actual, 0))::numeric /
-            (COALESCE(c.calls_target, 0) + COALESCE(c.emails_target, 0) + COALESCE(c.meetings_target, 0))::numeric) * 100
+            (
+              LEAST(COALESCE(r.calls_actual, 0)::numeric / GREATEST(COALESCE(c.calls_target, 1), 1)::numeric * 100, 100) * 0.3333 +
+              LEAST(COALESCE(r.emails_actual, 0)::numeric / GREATEST(COALESCE(c.emails_target, 1), 1)::numeric * 100, 100) * 0.3333 +
+              LEAST(COALESCE(r.meetings_actual, 0)::numeric / GREATEST(COALESCE(c.meetings_target, 1), 1)::numeric * 100, 100) * 0.3333
+            )
           )
           ELSE 0
         END as achievement_percentage

--- a/backend/src/routes/result.routes.ts
+++ b/backend/src/routes/result.routes.ts
@@ -39,8 +39,11 @@ router.get('/previous', authenticate, async (req: AuthRequest, res) => {
         emails: data.emails_target ? Math.round((data.emails_actual / data.emails_target) * 100) : 0,
         meetings: data.meetings_target ? Math.round((data.meetings_actual / data.meetings_target) * 100) : 0,
         overall: data.calls_target || data.emails_target || data.meetings_target
-          ? Math.round(((data.calls_actual + data.emails_actual + data.meetings_actual) / 
-              (data.calls_target + data.emails_target + data.meetings_target)) * 100)
+          ? Math.round((
+              Math.min((data.calls_actual / (data.calls_target || 1)) * 100, 100) * 0.3333 +
+              Math.min((data.emails_actual / (data.emails_target || 1)) * 100, 100) * 0.3333 +
+              Math.min((data.meetings_actual / (data.meetings_target || 1)) * 100, 100) * 0.3333
+            ))
           : 0
       }
     });
@@ -158,7 +161,14 @@ router.get('/history', authenticate, async (req: AuthRequest, res) => {
       percentages: {
         calls: row.calls_target ? Math.round((row.calls_actual / row.calls_target) * 100) : 0,
         emails: row.emails_target ? Math.round((row.emails_actual / row.emails_target) * 100) : 0,
-        meetings: row.meetings_target ? Math.round((row.meetings_actual / row.meetings_target) * 100) : 0
+        meetings: row.meetings_target ? Math.round((row.meetings_actual / row.meetings_target) * 100) : 0,
+        overall: row.calls_target || row.emails_target || row.meetings_target
+          ? Math.round((
+              Math.min((row.calls_actual / (row.calls_target || 1)) * 100, 100) * 0.3333 +
+              Math.min((row.emails_actual / (row.emails_target || 1)) * 100, 100) * 0.3333 +
+              Math.min((row.meetings_actual / (row.meetings_target || 1)) * 100, 100) * 0.3333
+            ))
+          : 0
       }
     }));
 
@@ -205,7 +215,14 @@ router.get('/user/:userId/week/:weekStart', authenticate, async (req: AuthReques
       percentages: {
         calls: data.calls_target ? Math.round((data.calls_actual / data.calls_target) * 100) : 0,
         emails: data.emails_target ? Math.round((data.emails_actual / data.emails_target) * 100) : 0,
-        meetings: data.meetings_target ? Math.round((data.meetings_actual / data.meetings_target) * 100) : 0
+        meetings: data.meetings_target ? Math.round((data.meetings_actual / data.meetings_target) * 100) : 0,
+        overall: data.calls_target || data.emails_target || data.meetings_target
+          ? Math.round((
+              Math.min((data.calls_actual / (data.calls_target || 1)) * 100, 100) * 0.3333 +
+              Math.min((data.emails_actual / (data.emails_target || 1)) * 100, 100) * 0.3333 +
+              Math.min((data.meetings_actual / (data.meetings_target || 1)) * 100, 100) * 0.3333
+            ))
+          : 0
       }
     });
   } catch (error) {
@@ -247,7 +264,14 @@ router.get('/user/:userId/history', authenticate, async (req: AuthRequest, res) 
       percentages: {
         calls: row.calls_target ? Math.round((row.calls_actual / row.calls_target) * 100) : 0,
         emails: row.emails_target ? Math.round((row.emails_actual / row.emails_target) * 100) : 0,
-        meetings: row.meetings_target ? Math.round((row.meetings_actual / row.meetings_target) * 100) : 0
+        meetings: row.meetings_target ? Math.round((row.meetings_actual / row.meetings_target) * 100) : 0,
+        overall: row.calls_target || row.emails_target || row.meetings_target
+          ? Math.round((
+              Math.min((row.calls_actual / (row.calls_target || 1)) * 100, 100) * 0.3333 +
+              Math.min((row.emails_actual / (row.emails_target || 1)) * 100, 100) * 0.3333 +
+              Math.min((row.meetings_actual / (row.meetings_target || 1)) * 100, 100) * 0.3333
+            ))
+          : 0
       }
     }));
 


### PR DESCRIPTION
Cap achievement tracking for calls, emails, and meetings at 33.33% weighting each to ensure balanced overall percentage calculation.

Previously, overperformance in one category could disproportionately inflate the overall achievement percentage. This change caps each category's contribution to a maximum of 33.33% of the total, ensuring a more balanced and accurate overall achievement score, with a maximum possible of 100%. The `overall` percentage calculation was also added to relevant API endpoints that were missing it.

---

[Open in Web](https://cursor.com/agents?id=bc-2cdf21b8-3624-4417-903f-7a7464c2289b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2cdf21b8-3624-4417-903f-7a7464c2289b) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)