### PR TITLE
Create AE resource hub for team updates

### DIFF
--- a/backend/src/routes/teamUpdate.routes.ts
+++ b/backend/src/routes/teamUpdate.routes.ts
@@ -5,6 +5,23 @@ import { authenticate, authorize, AuthRequest } from '../middleware/auth.middlew
 
 const router = Router();
 
+const ALLOWED_CATEGORIES = [
+  'start_here',
+  'cold_calling',
+  'prospecting',
+  'cos_qc_onboarding',
+  'performance_accountability',
+  'product_market',
+  'training_development',
+  'client_templates_proposals',
+  'meetings_internal_comms',
+  // Backward compatibility
+  'presentations',
+  'tickets',
+  'events',
+  'qc_updates',
+];
+
 // Get all team updates
 router.get('/', authenticate, async (req, res) => {
   try {
@@ -76,7 +93,7 @@ router.post('/', [
   authenticate,
   authorize('admin'),
   body('title').notEmpty().trim(),
-  body('category').isIn(['presentations', 'tickets', 'events', 'qc_updates'])
+  body('category').isIn(ALLOWED_CATEGORIES)
 ], async (req: AuthRequest, res: Response) => {
   try {
     const errors = validationResult(req);
@@ -119,7 +136,7 @@ router.put('/:id', [
   authenticate,
   authorize('admin'),
   body('title').optional().notEmpty().trim(),
-  body('category').optional().isIn(['presentations', 'tickets', 'events', 'qc_updates'])
+  body('category').optional().isIn(ALLOWED_CATEGORIES)
 ], async (req: AuthRequest, res: Response) => {
   try {
     const { id } = req.params;

--- a/backend/src/routes/teamUpdate.routes.ts
+++ b/backend/src/routes/teamUpdate.routes.ts
@@ -33,7 +33,7 @@ router.get('/', authenticate, async (req, res) => {
       LEFT JOIN users u ON tu.created_by = u.id
     `;
     
-    const values = [];
+    const values: any[] = [];
     
     if (category) {
       query += ' WHERE tu.category = $1';
@@ -49,6 +49,7 @@ router.get('/', authenticate, async (req, res) => {
       title: update.title,
       content: update.content,
       category: update.category,
+      section: update.section,
       fileUrl: update.file_url,
       externalLink: update.external_link,
       createdBy: update.created_by ? {
@@ -93,7 +94,9 @@ router.post('/', [
   authenticate,
   authorize('admin'),
   body('title').notEmpty().trim(),
-  body('category').isIn(ALLOWED_CATEGORIES)
+  body('category').isIn(ALLOWED_CATEGORIES),
+  body('section').optional().isString().trim().isLength({ max: 100 }),
+  body('externalLink').optional().isString().isLength({ max: 500 }),
 ], async (req: AuthRequest, res: Response) => {
   try {
     const errors = validationResult(req);
@@ -101,13 +104,13 @@ router.post('/', [
       return res.status(400).json({ errors: errors.array() });
     }
 
-    const { title, content, category, fileUrl, externalLink } = req.body;
+    const { title, content, category, section, fileUrl, externalLink } = req.body;
 
     const result = await pool.query(
-      `INSERT INTO team_updates (title, content, category, file_url, external_link, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6)
+      `INSERT INTO team_updates (title, content, category, section, file_url, external_link, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
        RETURNING *`,
-      [title, content || null, category, fileUrl || null, externalLink || null, req.user!.id]
+      [title, content || null, category, section || null, fileUrl || null, externalLink || null, req.user!.id]
     );
 
     const update = result.rows[0];
@@ -117,6 +120,7 @@ router.post('/', [
       title: update.title,
       content: update.content,
       category: update.category,
+      section: update.section,
       fileUrl: update.file_url,
       externalLink: update.external_link,
       createdBy: {
@@ -136,15 +140,17 @@ router.put('/:id', [
   authenticate,
   authorize('admin'),
   body('title').optional().notEmpty().trim(),
-  body('category').optional().isIn(ALLOWED_CATEGORIES)
+  body('category').optional().isIn(ALLOWED_CATEGORIES),
+  body('section').optional().isString().trim().isLength({ max: 100 }),
+  body('externalLink').optional().isString().isLength({ max: 500 }),
 ], async (req: AuthRequest, res: Response) => {
   try {
     const { id } = req.params;
-    const { title, content, category, fileUrl, externalLink } = req.body;
+    const { title, content, category, section, fileUrl, externalLink } = req.body;
 
     // Build update query dynamically
-    const updates = [];
-    const values = [];
+    const updates: string[] = [];
+    const values: any[] = [];
     let paramCount = 0;
 
     if (title !== undefined) {
@@ -163,6 +169,12 @@ router.put('/:id', [
       paramCount++;
       updates.push(`category = $${paramCount}`);
       values.push(category);
+    }
+
+    if (section !== undefined) {
+      paramCount++;
+      updates.push(`section = $${paramCount}`);
+      values.push(section);
     }
 
     if (fileUrl !== undefined) {
@@ -204,6 +216,7 @@ router.put('/:id', [
       title: update.title,
       content: update.content,
       category: update.category,
+      section: update.section,
       fileUrl: update.file_url,
       externalLink: update.external_link,
       updatedAt: update.updated_at

--- a/backend/src/utils/ensureCorrectSchema.ts
+++ b/backend/src/utils/ensureCorrectSchema.ts
@@ -41,6 +41,19 @@ export async function ensureCorrectSchema() {
       await pool.query('ALTER TABLE weekly_results RENAME COLUMN week_start TO week_start_date');
       console.log('Results table fixed!');
     }
+
+    // Ensure team_updates.section exists
+    const checkSection = await pool.query(`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_name = 'team_updates' AND column_name = 'section'
+    `);
+
+    if (checkSection.rows.length === 0) {
+      console.log('Adding section column to team_updates...');
+      await pool.query("ALTER TABLE team_updates ADD COLUMN section VARCHAR(100)");
+      console.log('section column added to team_updates');
+    }
     
     console.log('Schema check complete!');
     

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,11 +6,11 @@ import {
   Calendar,
   Target,
   Users,
-  MessageSquare,
   LogOut,
   Menu,
   X,
   ChevronDown,
+  BookOpen,
 } from 'lucide-react';
 import { useState } from 'react';
 import clsx from 'clsx';
@@ -27,7 +27,7 @@ const Layout = () => {
     { name: 'Leaderboard', href: '/leaderboard', icon: Trophy },
     { name: 'Weekly Commits', href: '/weekly-commits', icon: Calendar },
     { name: 'Daily Goals', href: '/daily-goals', icon: Target },
-    { name: 'Team Updates', href: '/team-updates', icon: MessageSquare },
+    { name: 'AE Hub', href: '/team-updates', icon: BookOpen },
   ];
 
   if (user?.role === 'admin') {
@@ -198,6 +198,15 @@ const Layout = () => {
                             <div className="px-4 py-2 text-xs text-gray-500 uppercase tracking-wide">
                               Admin
                             </div>
+                            <button
+                              onClick={() => {
+                                navigate('/users');
+                                setIsProfileDropdownOpen(false);
+                              }}
+                              className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                            >
+                              User Management
+                            </button>
                           </>
                         )}
                       </div>
@@ -209,9 +218,9 @@ const Layout = () => {
           </div>
         </div>
 
-        {/* Page Content */}
-        <main className="flex-1">
-          <div className="py-6 px-4 sm:px-6 lg:px-8">
+        {/* Outlet */}
+        <main className="py-6">
+          <div className="px-4 sm:px-6 lg:px-8">
             <Outlet />
           </div>
         </main>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -13,6 +13,7 @@ import {
   CheckCircle,
   Target,
   Trophy,
+  BookOpen,
 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import type { WeeklyCommitment, WeeklyResult } from '@/types';
@@ -430,10 +431,10 @@ const Dashboard = () => {
         </Link>
         <Link to="/team-updates" className="card hover:shadow-md transition-shadow">
           <div className="flex items-center">
-            <AlertCircle className="h-10 w-10 text-blue-600 mr-3" />
+            <BookOpen className="h-10 w-10 text-blue-600 mr-3" />
             <div>
-              <h3 className="font-semibold">Team Updates</h3>
-              <p className="text-sm text-gray-600">Latest announcements</p>
+              <h3 className="font-semibold">AE Hub</h3>
+              <p className="text-sm text-gray-600">Documents & resources</p>
             </div>
           </div>
         </Link>

--- a/frontend/src/pages/TeamUpdates.tsx
+++ b/frontend/src/pages/TeamUpdates.tsx
@@ -1,24 +1,28 @@
 import { useState, useEffect } from 'react';
 import { teamUpdateApi } from '@/services/api';
 import { useAuth } from '@/contexts/AuthContext';
-import { MessageSquare, FileText, Link as LinkIcon, Calendar, Tag, Plus, Edit2, Trash2 } from 'lucide-react';
+import { MessageSquare, FileText, Link as LinkIcon, Tag, Plus, Edit2, Trash2, BookOpen, Phone, Search, ShieldCheck, BarChart2, Box, GraduationCap, Users } from 'lucide-react';
 import { format } from 'date-fns';
 import toast from 'react-hot-toast';
 import type { TeamUpdate } from '@/types';
 
-const categoryIcons = {
-  presentations: FileText,
-  tickets: LinkIcon,
-  events: Calendar,
-  qc_updates: Tag,
-};
+const HUB_CATEGORY_DEFS = {
+  start_here: { label: 'Start Here - New Joiners Guides', Icon: BookOpen },
+  cold_calling: { label: 'Cold Calling', Icon: Phone },
+  prospecting: { label: 'Prospecting', Icon: Search },
+  cos_qc_onboarding: { label: 'Cos, QC & Onboarding', Icon: ShieldCheck },
+  performance_accountability: { label: 'Performance and Accountability', Icon: BarChart2 },
+  product_market: { label: 'Product and Market', Icon: Box },
+  training_development: { label: 'Extra Training and Development', Icon: GraduationCap },
+  client_templates_proposals: { label: 'Client templates and proposals', Icon: FileText },
+  meetings_internal_comms: { label: 'Meetings and Internal Comms', Icon: Users },
+} as const;
 
-const categoryLabels = {
-  presentations: 'Presentations & Guides',
-  tickets: 'Ticket Links',
-  events: 'Upcoming Events',
-  qc_updates: 'QC Updates',
-};
+function formatCategoryLabel(key: string): string {
+  return key
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
 
 const TeamUpdates = () => {
   const { user } = useAuth();
@@ -50,7 +54,7 @@ const TeamUpdates = () => {
     const updateData = {
       title: formData.get('title') as string,
       content: formData.get('content') as string,
-      category: formData.get('category') as 'presentations' | 'tickets' | 'events' | 'qc_updates',
+      category: formData.get('category') as TeamUpdate['category'],
       externalLink: formData.get('externalLink') as string,
     };
 
@@ -104,10 +108,10 @@ const TeamUpdates = () => {
           <div>
             <h1 className="text-2xl font-bold flex items-center">
               <MessageSquare className="h-8 w-8 mr-3" />
-              Team Updates
+              AE Hub
             </h1>
             <p className="mt-2 text-primary-100">
-              Important announcements and resources
+              Documents, templates, and resources for Account Executives
             </p>
           </div>
           {user?.role === 'admin' && (
@@ -119,7 +123,7 @@ const TeamUpdates = () => {
               className="btn-primary bg-white text-primary-600 hover:bg-gray-100"
             >
               <Plus className="h-5 w-5 mr-2" />
-              New Update
+              New Resource
             </button>
           )}
         </div>
@@ -138,7 +142,7 @@ const TeamUpdates = () => {
           >
             All Categories
           </button>
-          {Object.entries(categoryLabels).map(([key, label]) => (
+          {Object.entries(HUB_CATEGORY_DEFS).map(([key, def]) => (
             <button
               key={key}
               onClick={() => setSelectedCategory(key)}
@@ -148,7 +152,7 @@ const TeamUpdates = () => {
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
               }`}
             >
-              {label}
+              {def.label}
             </button>
           ))}
         </div>
@@ -158,7 +162,7 @@ const TeamUpdates = () => {
       {showForm && (
         <div className="card">
           <h2 className="text-lg font-semibold mb-4">
-            {editingUpdate ? 'Edit Update' : 'Create New Update'}
+            {editingUpdate ? 'Edit Resource' : 'Create New Resource'}
           </h2>
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
@@ -181,8 +185,8 @@ const TeamUpdates = () => {
                 className="input-field mt-1"
               >
                 <option value="">Select category</option>
-                {Object.entries(categoryLabels).map(([key, label]) => (
-                  <option key={key} value={key}>{label}</option>
+                {Object.entries(HUB_CATEGORY_DEFS).map(([key, def]) => (
+                  <option key={key} value={key}>{def.label}</option>
                 ))}
               </select>
             </div>
@@ -233,11 +237,13 @@ const TeamUpdates = () => {
         {updates.length === 0 ? (
           <div className="card text-center py-12">
             <MessageSquare className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-            <p className="text-gray-500">No updates found</p>
+            <p className="text-gray-500">No resources found</p>
           </div>
         ) : (
           updates.map((update) => {
-            const Icon = categoryIcons[update.category as keyof typeof categoryIcons];
+            const def = HUB_CATEGORY_DEFS[update.category as keyof typeof HUB_CATEGORY_DEFS];
+            const Icon = def?.Icon || Tag;
+            const label = def?.label || formatCategoryLabel(update.category);
             return (
               <div key={update.id} className="card hover:shadow-md transition-shadow">
                 <div className="flex items-start justify-between">
@@ -245,7 +251,7 @@ const TeamUpdates = () => {
                     <div className="flex items-center mb-2">
                       <Icon className="h-5 w-5 text-primary-600 mr-2" />
                       <span className="text-sm font-medium text-primary-600">
-                        {categoryLabels[update.category as keyof typeof categoryLabels]}
+                        {label}
                       </span>
                       <span className="text-sm text-gray-500 ml-2">
                         • {format(new Date(update.createdAt), 'MMM d, yyyy')}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -127,6 +127,7 @@ export const teamUpdateApi = {
     title: string;
     content?: string;
     category: TeamUpdate['category'];
+    section?: string;
     fileUrl?: string;
     externalLink?: string;
   }) => api.post<TeamUpdate>('/team-updates', data),

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -126,7 +126,7 @@ export const teamUpdateApi = {
   create: (data: {
     title: string;
     content?: string;
-    category: string;
+    category: TeamUpdate['category'];
     fileUrl?: string;
     externalLink?: string;
   }) => api.post<TeamUpdate>('/team-updates', data),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -58,7 +58,21 @@ export interface TeamUpdate {
   id: number;
   title: string;
   content?: string;
-  category: 'presentations' | 'tickets' | 'events' | 'qc_updates';
+  category:
+    | 'start_here'
+    | 'cold_calling'
+    | 'prospecting'
+    | 'cos_qc_onboarding'
+    | 'performance_accountability'
+    | 'product_market'
+    | 'training_development'
+    | 'client_templates_proposals'
+    | 'meetings_internal_comms'
+    // Backward compatibility with existing categories
+    | 'presentations'
+    | 'tickets'
+    | 'events'
+    | 'qc_updates';
   fileUrl?: string;
   externalLink?: string;
   createdBy?: {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -73,6 +73,7 @@ export interface TeamUpdate {
     | 'tickets'
     | 'events'
     | 'qc_updates';
+  section?: string;
   fileUrl?: string;
   externalLink?: string;
   createdBy?: {


### PR DESCRIPTION
Converts the 'Team Updates' page into an 'AE Hub' to centralize resources for Account Executives with new categories.

---
<a href="https://cursor.com/background-agent?bcId=bc-93185073-50b8-4173-af90-d96483d62e39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-93185073-50b8-4173-af90-d96483d62e39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

